### PR TITLE
Fix version display in configuration menu

### DIFF
--- a/modules/ConfigMenu.lua
+++ b/modules/ConfigMenu.lua
@@ -143,7 +143,14 @@ local function GetAddonVersion()
   elseif GetAddOnMetadata then
     version = GetAddOnMetadata("NoobTacoUI-Media", "Version")
   end
-  return version or "1.0.9"
+
+  -- Check if version is the placeholder token or invalid
+  if not version or version == "@project-version@" or version == "" then
+    -- During development, use a meaningful fallback
+    version = "dev-build"
+  end
+
+  return version
 end
 VersionText:SetText("v" .. GetAddonVersion())
 


### PR DESCRIPTION
Fixes #15

## Problem
The version number in the configuration menu was not displaying correctly due to the placeholder token not being handled properly during development.

## Solution
- Handle placeholder token properly
- Show 'dev-build' during development
- Improve version detection logic for both packaged and development builds

## Testing
- Luacheck passes with 0 warnings/0 errors
- Version detection logic handles all edge cases

## Expected Behavior
- Development: Config menu shows 'v dev-build'
- Packaged Release: Config menu shows actual version like 'v1.1.1'